### PR TITLE
fix trim options divider

### DIFF
--- a/src/intellisense/AutoComplete.test.ts
+++ b/src/intellisense/AutoComplete.test.ts
@@ -523,6 +523,27 @@ describe("AutoComplete", () => {
         expect(result.options).toEqual([{ text: 'a', startIndex: 4 }]);
     });
 
+    test("Remove options divider", () => {
+        const jediLuke = new Literal(`jedi`, 'luke');
+        const names = new Options('names', [jediLuke]);
+        const literalA = new Literal('literal-a', 'a');
+        const literalB = new Literal('literal-b', 'b');
+
+        const optionsDivider = new Options('options-divider', [literalA, literalB]);
+
+        // control to prove the pattern works without trimDivider
+        const controlPattern = new Repeat('name-list', names, { divider: optionsDivider });
+        const controlAutoComplete = new AutoComplete(controlPattern);
+        const controlResult = controlAutoComplete.suggestFor('lukea');
+        expect(controlResult.isComplete).toEqual(true);
+
+        const trimPattern = new Repeat('name-list', names, { divider: optionsDivider, trimDivider: true });
+        const trimAutoComplete = new AutoComplete(trimPattern);
+
+        const trimResult = trimAutoComplete.suggestFor('lukea');
+        expect(trimResult.isComplete).toEqual(false);
+    })
+
     test("Expect Divider", () => {
         const repeat = new Repeat("repeat", new Literal("a", "a"), { divider: new Literal("pipe", "|") });
         const autoComplete = new AutoComplete(repeat);

--- a/src/patterns/InfiniteRepeat.ts
+++ b/src/patterns/InfiniteRepeat.ts
@@ -221,10 +221,13 @@ export class InfiniteRepeat implements Pattern {
   private _createNode(cursor: Cursor): Node | null {
     const hasDivider = this._divider != null;
 
+    const previousNode = this._nodes[this._nodes.length - 1]
+    const dividerPatternNames = this._getDividerPatternNames()
+
     if (
       hasDivider &&
       this._trimDivider &&
-      this._nodes[this._nodes.length - 1].name === this._divider?.name
+      dividerPatternNames.includes(previousNode.name)
     ) {
       const dividerNode = this._nodes.pop() as Node;
       cursor.moveTo(dividerNode.firstIndex);
@@ -245,6 +248,15 @@ export class InfiniteRepeat implements Pattern {
       lastIndex,
       this._nodes
     );
+  }
+
+  // previous node may correlate to a child of the divider pattern; ie. in the case of Options.
+  // so we gather all the names of the divider pattern and its children for comparison
+  private _getDividerPatternNames(): string[] {
+    const dividerPattern = this._divider
+    const dividerPatternName = dividerPattern?.name?[dividerPattern.name]:[]
+    const dividerPatternsChildrenNames = dividerPattern?.children.map(p => p.name) ?? []
+    return [...dividerPatternName, ...dividerPatternsChildrenNames]
   }
 
   private _getLastValidNode(): Node | null {


### PR DESCRIPTION
## Issue

### Scenario
when defining a `Repeat` pattern with a `Divider` that is a `Optional` node, and setting trimDivider to true.

Issue: 
Calling autocomplete.suggestFor with text matching a completed option (divider) would return `isComplete:  true` instead of `false` as the node ends with the OptionsNode, and should be "trimmed"

resolved by comparing against the divider node's children's names, in addition to the divider nodes name.
